### PR TITLE
Implemented feature whereby folders can be excluded from the search.

### DIFF
--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -3,7 +3,7 @@
   "message": "Quick Folder Key Navigation"
   },
   "extensionDescription": {
-    "message": "This extension makes it possible to quickly navigate to a particular folder in the folder pane  by clicking on the \"QuickNav\" button (or pressing F4) and  typing the first few letters of the folder name into the Search box that appears. If multiple folders start with the same prefix, you can cycle through them using  the up and down arrow keys. Click the \"Go\" button (or press ENTER) to jump to the selected folder or Esc to cancel the operation. Using the Search method control, The way searching is carried out can be  changed to \"Match anywhere\" to allow searching for text that appears anywhere in the folder name, instead of only at the beginning of the folder name, which is what  the default \"Match from  start\" method does. In Thunderbird 121.0 and later, an additional \"Go to new tab\" button (or   pressing CTRL+ENTER) allows the selected folder to be opened in a new mail tab. Note for JAWS users:  if you have Forms Mode set to Manual, it is necessary to press ENTER when the QuickNav dialog opens in order to type into the search box. As this is extremely  inconvenient, it is recommended that you uncheck  the \"Disable forms Mode when a  new page is loaded\" option in JAWS Settings Center. This will cause you to be placed  into the edit field immediately when the QuickNav dialog opens. Alternatively, this can also be achieved by setting Forms Mode to anything other than Manual. The verbosity of  screen-reader speech can be adjusted using the \"Screen-reader verbosity\" combo box  in the QuickNav dialog."
+    "message": "This extension makes it possible to quickly navigate to a particular folder in the folder pane  by clicking on the \"QuickNav\" button (or pressing F4) and  typing the first few letters of the folder name into the Search box that appears. If multiple folders start with the same prefix, you can cycle through them using  the up and down arrow keys. Alternatively, you can also use CTRL+p and CTRL+n. Click the \"Go\" button (or press ENTER) to jump to the selected folder or Esc to cancel the operation. Using the Search method control, The way searching is carried out can be  changed to \"Match anywhere\" to allow searching for text that appears anywhere in the folder name, instead of only at the beginning of the folder name, which is what  the default \"Match from  start\" method does. In Thunderbird 121.0 and later, an additional \"Go to new tab\" button (or   pressing CTRL+ENTER) allows the selected folder to be opened in a new mail tab. Note for JAWS users:  if you have Forms Mode set to Manual, it is necessary to press ENTER when the QuickNav dialog opens in order to type into the search box. As this is extremely  inconvenient, it is recommended that you uncheck  the \"Disable forms Mode when a  new page is loaded\" option in JAWS Settings Center. This will cause you to be placed  into the edit field immediately when the QuickNav dialog opens. Alternatively, this can also be achieved by setting Forms Mode to anything other than Manual. The verbosity of  screen-reader speech can be adjusted using the \"Screen-reader verbosity\" combo box  in the QuickNav dialog."
   },
   "actionButtonLabel": {
     "message": "QuickNav"
@@ -41,11 +41,23 @@
   "anywhereLabel": {
     "message": "Match anywhere"
   },
+  "hiddenFoldersLabel": {
+    "message": "Hidden folders"
+  },
+  "hideFolderLabel": {
+    "message": "Hide folder"
+  },
+  "showFolderLabel": {
+    "message": "Show folder"
+  },
+  "showAllFoldersLabel": {
+    "message": "Show all folders"
+  },
   "whatsnew_title": {
     "message": "What's New in Quick Folder Key Navigation"
   },
   "whatsnew_text": {
-   "message": "This update allows you to cycle forward and backward  through the set of matching folders using Ctrl+n and Ctrl+p respectively, in addition to the down arrow and up arrow     keys."
+   "message": "Folders can now be excluded from the search by hiding them. The \"Hide\" button (or pressing CTRL+Delete) adds the currently selected folder to the hidden folders list. To make a hidden folder searchable once again, select it in the Hidden folders combo box and either click the \"Show folder\" button or press the Delete key. Clicking the \"Show all folders\" button or pressing CTRL+Delete clears the hidden folder list, making all folders searchable once again. The hidden folder list is saved locally and restored each time Thunderbird is started."
   },
   "btnCloseLabel": {
     "message": "Close"

--- a/_locales/es/messages.json
+++ b/_locales/es/messages.json
@@ -3,7 +3,7 @@
   "message": "Acceso Rápido a Carpetas"
   },
   "extensionDescription": {
-    "message": "Esta extensión permite navegar rápidamente a una carpeta particular en el panel de carpetas haciendo clic en el botón \"QuickNav\" (o presionando F4) y escribiendo las primeras letras del nombre de la carpeta en el cuadro de búsqueda que aparece. Si varias carpetas comienzan con el mismo prefijo, puede recorrerlas usando las teclas de flecha hacia arriba y hacia abajo. Haga clic en el botón \"Ir\" (o presione ENTER) para saltar a la carpeta seleccionada o Esc para cancelar la operación. Usando el control del método de búsqueda, la forma en que se realiza la búsqueda se puede cambiar para \"Coincidir en cualquier lugar\" para permitir la búsqueda de texto que aparece en cualquier parte del nombre de la carpeta, en lugar de solo al principio del nombre de la carpeta, que es el método  predeterminado \"Coincidir desde el principio\".  En Thunderbird 121.0 y versiones posteriores, un botón adicional \"Ir a una nueva pestaña\" (o presionar CTRL+ENTER) permite abrir la carpeta seleccionada en una nueva pestaña de correo. Nota para los usuarios de JAWS: si tiene el Modo de formularios configurado en Manual, es necesario presionar ENTER cuando se abra el cuadro de diálogo AccesoRápido para escribir en el campo  de búsqueda. Como esto es extremadamente inconveniente, se recomienda que desmarque la opción \"Deshabilitar el modo de formularios cuando se carga una nueva página\" en el Centro de configuración de JAWS. Esto hará que se le coloque en el campo de edición inmediatamente cuando se abra el cuadro de diálogo AccesoRápido. Alternativamente, esto también se puede lograr configurando el Modo de formularios en cualquier otra cosa que no sea Manual. La verbosidad del lector de pantalla se puede ajustar mediante el cuadro combinado \"Verbosidad del lector de pantalla\" en el cuadro de diálogo AccesoRápido."
+    "message": "Esta extensión permite navegar rápidamente a una carpeta particular en el panel de carpetas haciendo clic en el botón \"QuickNav\" (o presionando F4) y escribiendo las primeras letras del nombre de la carpeta en el cuadro de búsqueda que aparece. Si varias carpetas comienzan con el mismo prefijo, puede recorrerlas usando las teclas de flecha hacia arriba y hacia abajo. También, se puede usar CTRL+p y CTRL+n. Haga clic en el botón \"Ir\" (o presione ENTER) para saltar a la carpeta seleccionada o Esc para cancelar la operación. Usando el control del método de búsqueda, la forma en que se realiza la búsqueda se puede cambiar para \"Coincidir en cualquier lugar\" para permitir la búsqueda de texto que aparece en cualquier parte del nombre de la carpeta, en lugar de solo al principio del nombre de la carpeta, que es el método  predeterminado \"Coincidir desde el principio\".  En Thunderbird 121.0 y versiones posteriores, un botón adicional \"Ir a una nueva pestaña\" (o presionar CTRL+ENTER) permite abrir la carpeta seleccionada en una nueva pestaña de correo. Nota para los usuarios de JAWS: si tiene el Modo de formularios configurado en Manual, es necesario presionar ENTER cuando se abra el cuadro de diálogo AccesoRápido para escribir en el campo  de búsqueda. Como esto es extremadamente inconveniente, se recomienda que desmarque la opción \"Deshabilitar el modo de formularios cuando se carga una nueva página\" en el Centro de configuración de JAWS. Esto hará que se le coloque en el campo de edición inmediatamente cuando se abra el cuadro de diálogo AccesoRápido. Alternativamente, esto también se puede lograr configurando el Modo de formularios en cualquier otra cosa que no sea Manual. La verbosidad del lector de pantalla se puede ajustar mediante el cuadro combinado \"Verbosidad del lector de pantalla\" en el cuadro de diálogo AccesoRápido."
   },
   "actionButtonLabel": {
     "message": "AccesoRápido"
@@ -41,11 +41,23 @@
   "anywhereLabel": {
     "message": "Coincidir en cualquier lugar"
   },
+  "hiddenFoldersLabel": {
+    "message": "Carpetas ocultas"
+  },
+  "hideFolderLabel": {
+    "message": "Ocultar carpeta"
+  },
+  "showFolderLabel": {
+    "message": "Mostrar carpeta"
+  },
+  "showAllFoldersLabel": {
+    "message": "Mostrar todas las carpetas"
+  },
   "whatsnew_title": {
     "message": "Qué es nuevo en Acceso Rápido a Carpetas"
   },
   "whatsnew_text": {
-   "message": "Esta  actualización le permite avanzar y retroceder a través del conjunto de carpetas coincidentes utilizando Ctrl+n y Ctrl+p respectivamente, además de las teclas de flecha hacia abajo y flecha hacia arriba."
+   "message": "Ahora es posible excluir carpetas de la búsqueda ocultándolas. El botón \"Ocultar\" (o pulsar Ctrl+Supr) añade la carpeta seleccionada a la lista de carpetas ocultas. Para que una carpeta oculta vuelva a ser buscable, selecciónela en el cuadro combinado \"Carpetas ocultas\" y haga clic en el botón \"Mostrar carpeta\" o pulse la tecla Supr. Al hacer clic en el botón \"Mostrar todas las carpetas\" o pulsar Ctrl+Supr, se borra la lista de carpetas ocultas, lo que permite buscar en todas las carpetas. La lista de carpetas ocultas se guarda localmente y se restaura cada vez que se inicia Thunderbird."
   },
   "btnCloseLabel": {
     "message": "Cerrar"

--- a/manifest.json
+++ b/manifest.json
@@ -3,7 +3,7 @@
   "name": "__MSG_extensionName__",
   "description": "__MSG_extensionDescription__",
   "author": "Andrew Hart",
-  "version": "4.4",
+  "version": "4.5",
   "homepage_url": "https://github.com/hartag/keynav",
   "default_locale": "en",
 

--- a/popup/popup.css
+++ b/popup/popup.css
@@ -13,7 +13,7 @@ label {
   line-height: 1.8em ;
 }
 
-input {
+input, select, button {
   margin: 0.5em;
 }
 
@@ -22,14 +22,14 @@ input {
 }
 
 .spacedhbox {
-  display:flex;
+  display: flex;
   flex-direction: row;
   justify-content: space-around;
   align-items: center;
 }
 
 .betweendhbox {
-  display:flex;
+  display: flex;
   flex-direction: row;
   justify-content: space-between;
   align-items: center;
@@ -40,7 +40,7 @@ input {
 }
 
 #currentFolder {
-  display:flex;
+  display: flex;
   flex-direction: row;
   justify-content: flex-start;
   align-items: center;

--- a/popup/popup.html
+++ b/popup/popup.html
@@ -19,7 +19,7 @@
     <div role="application" aria-labelledby="quick-nav" tabindex="-1">
       <div class="betweenhbox">
         <label for="search-text" data-l10n-id="searchLabel"></label>
-        <input type="text" id="search-text" tabindex="3">
+        <input type="text" id="search-text" tabindex="4">
         <div id="idx" tabindex="-1"></div>
       </div>
 
@@ -28,26 +28,39 @@
         <span id="announce" aria-live="assertive"></span>
       </div>
 
-        <div class="betweenhbox">
-          <button id="btnGo" data-l10n-id="btnGoLabel" tabindex="4"></button>
-          <button id="btnGoNew" data-l10n-id="btnGoNewLabel" tabindex="4"></button>
-          <button id="btnCancel" data-l10n-id="btnCancelLabel" tabindex="6"></button>
-        </div>
+      <div class="betweenhbox">
+        <button id="hide-folder" data-l10n-id="hideFolderLabel" tabindex="5"></button>
+        <button id="btnGo" data-l10n-id="btnGoLabel" tabindex="6"></button>
+        <button id="btnGoNew" data-l10n-id="btnGoNewLabel" tabindex="6"></button>
+        <button id="btnCancel" data-l10n-id="btnCancelLabel" tabindex="6"></button>
+      </div>
 
+      <div class="spacedhbox">
+        <label for="verbosity" data-l10n-id="verbosityModeLabel"></label>
+        <select id="verbosity" tabindex="1">
+          <option value="concise" data-l10n-id="conciseLabel"></option>
+          <option value="folder" data-l10n-id="FolderOnlyLabel"></option>
+          <option value="whole" data-l10n-id="wholeLabel"></option>
+        </select>
+
+        <label for="search-type" data-l10n-id="searchTypeLabel"></label>
+        <select id="search-type" tabindex="3">
+          <option value="start" data-l10n-id="atStartLabel"></option>
+          <option value="anywhere" data-l10n-id="anywhereLabel"></option>
+        </select>
+      </div>
+
+      <div>
+        <div>
+          <label for="hidden-folders" data-l10n-id="hiddenFoldersLabel"></label>
+          <select id="hidden-folders" tabindex="7">
+          </select>
+        </div>
         <div class="spacedhbox">
-          <label for="verbosity" data-l10n-id="verbosityModeLabel"></label>
-          <select id="verbosity" tabindex="1">
-            <option value="concise" data-l10n-id="conciseLabel"></option>
-            <option value="folder" data-l10n-id="FolderOnlyLabel"></option>
-            <option value="whole" data-l10n-id="wholeLabel"></option>
-          </select>
-
-          <label for="search-type" data-l10n-id="searchTypeLabel"></label>
-          <select id="search-type" tabindex="2">
-            <option value="start" data-l10n-id="atStartLabel"></option>
-            <option value="anywhere" data-l10n-id="anywhereLabel"></option>
-          </select>
+          <button id="show-folder" data-l10n-id="showFolderLabel" tabindex="7"></button>
+          <button id="show-all-folders" data-l10n-id="showAllFoldersLabel" tabindex="7"></button>
         </div>
+      </div>
 
     </div>
   </body>


### PR DESCRIPTION
. Now, folders can be excluded from the search by hiding them. They can be
  made searchable again by selecting them in the Hidden folders combo box
  and clicking the Show folder button. The list of hidden folders is
  saved to local storage and retrieved each time QuickNav opens. There
  are also some hotkeys for hidng and showing from the keyboard

. Bumped the version to 4.5.