### PR TITLE
feat: multiple search terms

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,7 +24,7 @@ all : $(XPI-FILE)
 $(XPI-FILE): $(SRC-FILES)
 	@echo Generating $(XPI-FILE).
 	@zip -qr $(XPI-FILE) $(SRC-FILES)
-	
+
 .PHONEY: clean version
 clean:
 	-@rm -f *.xpi
@@ -32,4 +32,4 @@ clean:
 
 version:
 	@echo $(EXT-NAME) version $(EXT-VERSION)
-	
+

--- a/README.md
+++ b/README.md
@@ -4,51 +4,51 @@
 
 This is an extension (add-on) for Thunderbird that makes it possible to quickly jump
   to a desired folder in the folder tree. In Thunderbird version 102
- and earlier, one can quickly navigate the folder tree by typing 
-the first part or all of a folder name when the folder tree has the 
+ and earlier, one can quickly navigate the folder tree by typing
+the first part or all of a folder name when the folder tree has the
 focus.
 
 Note that single-letter Thunderbird short-cuts (such as "n" and "p" which move to the next and previous unread messages respectively) do not work in the
 folder pane when key navigation is enabled. Therefore, There is an option to turn key navigation on/off, as well as for adding this item to the context
 menu when the folder pane has the focus.
 
-The Thunderbird UI was completely redesigned in Thunderbird 115. As a 
-consequence, the mail folder tree is not  capable of responding to 
-key presses and QuickNav can no longer take advantage of this 
-functionality. Instead, QuickNav makes it possible to quickly 
-navigate to a particular folder in the folder pane  in Thunderbird 
-115.0 and later by clicking on the "QuickNav" button (or pressing 
-F4) and  typing the first few letters of the folder name into the 
-Search box that appears. If multiple folders start with the same 
-prefix, you can cycle through them using  the up and down arrow 
+The Thunderbird UI was completely redesigned in Thunderbird 115. As a
+consequence, the mail folder tree is not  capable of responding to
+key presses and QuickNav can no longer take advantage of this
+functionality. Instead, QuickNav makes it possible to quickly
+navigate to a particular folder in the folder pane  in Thunderbird
+115.0 and later by clicking on the "QuickNav" button (or pressing
+F4) and  typing the first few letters of the folder name into the
+Search box that appears. If multiple folders start with the same
+prefix, you can cycle through them using  the up and down arrow
 keys. Click the "Go" button (or press ENTER) to jump to the selected
- folder or Esc to cancel the operation. 
+ folder or Esc to cancel the operation.
 
 Using the Search method control, The way searching is carried out can be
- changed to "match anywhere" to allow searching for text that 
-appears anywhere in the folder name, instead of only at the 
+ changed to "match anywhere" to allow searching for text that
+appears anywhere in the folder name, instead of only at the
 beginning of the folder name, which is what  the default "Match from
  start" method does.
 
 In Thunderbird 121.0 and later, an additional "Go to new tab" button (or
-  pressing CTRL+ENTER) allows the selected folder to be opened in a 
+  pressing CTRL+ENTER) allows the selected folder to be opened in a
 new mail tab.
 
 **Note for JAWS users:**
- if you have Forms Mode set to Manual, it is necessary to press 
-ENTER when the QuickNav dialog opens in order to type into the 
-search box. As this is extremely  inconvenient, it is recommended 
-that you uncheck  the 'Disable forms Mode when a  new page is 
-loaded' option in JAWS Settings Center. This will cause you to be 
-placed  into the edit field immediately when the QuickNav dialog 
-opens. Alternatively, this can also be achieved by setting Forms 
-Mode to anything other than Manual. The verbosity of  screen-reader 
+ if you have Forms Mode set to Manual, it is necessary to press
+ENTER when the QuickNav dialog opens in order to type into the
+search box. As this is extremely  inconvenient, it is recommended
+that you uncheck  the 'Disable forms Mode when a  new page is
+loaded' option in JAWS Settings Center. This will cause you to be
+placed  into the edit field immediately when the QuickNav dialog
+opens. Alternatively, this can also be achieved by setting Forms
+Mode to anything other than Manual. The verbosity of  screen-reader
 speech can be adjusted using the 'Screen-reader verbosity' combo box
  in the QuickNav dialog.
 
 ## Getting the Add-on
 
-The easiest way to get Quick Folder Key Navigation is to search for it and install 
+The easiest way to get Quick Folder Key Navigation is to search for it and install
 it from the Add-ons Manager from within Thunderbird itself.
 
 ## Building From Source
@@ -57,17 +57,17 @@ If you want to build it and install it yourself, here's how to do it.
 
 ### Building the Add-on
 
-In addition to a shell such as bash, the following standard Linux/Unix  
-utilities will be required in order to build the extension: make, cat, 
+In addition to a shell such as bash, the following standard Linux/Unix
+utilities will be required in order to build the extension: make, cat,
 grep, head, sed, zip.
 
 Building the extension is straightforward. After cloning the repository
 or downloading an archive of the repository and extracting it to a
-directory, simply type `make` at the command prompt to build the .xpi 
+directory, simply type `make` at the command prompt to build the .xpi
 file.
 
-In addition, `make version` will display the source code version and `make 
-clean` will clean up the repository folder structure, deleting the xpi file, as 
+In addition, `make version` will display the source code version and `make
+clean` will clean up the repository folder structure, deleting the xpi file, as
 well as files with names like *.bak, etc.
 
 ### Installing the add-on
@@ -79,5 +79,5 @@ Once you have the xpi file, it can be installed using the following procedure.
   3. Click on the "Tools for all add-ons" button, which appears as a cog wheel. It is just before the "Search all add-ons" edit field in the tab order.
   4. Click on the "Install Add-on from file" item in the pop-up menu that appears.
   5. An open file dialog wil appear. Use it to select the xpi file for the keynav add-on.
-  6. Follow the instructions to complete the installation. 
-  
+  6. Follow the instructions to complete the installation.
+

--- a/background.js
+++ b/background.js
@@ -12,9 +12,9 @@ messenger.commands.onCommand.addListener((command, tab) => {
   }
   messenger.browserAction.openPopup();
 });
-	
+
 // Show a What's New dialog
-messenger.runtime.onInstalled.addListener(	details => {
+messenger.runtime.onInstalled.addListener(details => {
   if (details.reason=="update") {
     messenger.windows.create({
       allowScriptsToClose: true,

--- a/common.js
+++ b/common.js
@@ -7,17 +7,17 @@
 "use strict";
 
 // Localise page
-// Search  for page elements with a data-l10n-id attribute, which holds 
-// an id corresponding to a localization string retrievable via 
+// Search  for page elements with a data-l10n-id attribute, which holds
+// an id corresponding to a localization string retrievable via
 // messenger.i18n.getMessage. For each such string, do the following:
-// - If it contains no "\n" char, copy it directly into the element's 
+// - If it contains no "\n" char, copy it directly into the element's
 //   textContent.
-// - If it contains "\n\n" sequences, append each segment delimited 
+// - If it contains "\n\n" sequences, append each segment delimited
 //   by "\n\n" to the element as the textContent of a p element.
-// - Otherwise, it contains isolated "\n" chars. Append the segments 
-//   bounded by "\n" as text nodes to the element and the "\n" chars 
+// - Otherwise, it contains isolated "\n" chars. Append the segments
+//   bounded by "\n" as text nodes to the element and the "\n" chars
 //   themselves as br elements.
-// 
+//
 function localisePage() {
   for (let el of document.querySelectorAll("[data-l10n-id]")) {
     let id = el.getAttribute("data-l10n-id");
@@ -32,8 +32,8 @@ function localisePage() {
 
 // appendLines
 // if text contains no "\n"chars, copy it to   el.textContent. Otherwise,
-// split up the  string in text using "\n" as the separator. Then, append 
-// each segment to el as a text node and insert a br element between each 
+// split up the  string in text using "\n" as the separator. Then, append
+// each segment to el as a text node and insert a br element between each
 // pair of text nodes.
 function appendLines(el, text) {
   if (!text.includes("\n")) {
@@ -54,7 +54,7 @@ function appendLines(el, text) {
 }
 
 // appendParagraphs
-// Split text up using "\n\n" as a separator. Stuff  each segment into 
+// Split text up using "\n\n" as a separator. Stuff  each segment into
 // a p element using appendLines and then append it to el.
 function appendParagraphs(el, text) {
   let paragraphs = text.split("\n\n");

--- a/keynav.html
+++ b/keynav.html
@@ -7,30 +7,30 @@ Quick folder Key Navigation (keynav)  Add-on for Thunderbird
 
 <script>
 function toggleSuggestions() {
-	var button = document.getElementById("suggestionsButton");
-	var text = document.getElementById("suggestions");
-	var displayState = text.style.display;
-	if (displayState=="none") {
-		text.style.display = "block";
-		button.innerHTML = "Hide suggestions.";
-	} else {
-		text.style.display = "none";
-		button.innerHTML = "Show some suggestions for how to accomplish this.";
-	}
+  var button = document.getElementById("suggestionsButton");
+  var text = document.getElementById("suggestions");
+  var displayState = text.style.display;
+  if (displayState=="none") {
+    text.style.display = "block";
+    button.innerHTML = "Hide suggestions.";
+  } else {
+    text.style.display = "none";
+    button.innerHTML = "Show some suggestions for how to accomplish this.";
+  }
 }
-	</script>
+  </script>
 
 </head>
 
 <body>
 <h1>The keynav Add-on</h1>
 
-<p>Quick Folder Key Navigation (keynav) is an add-on for Thunderbird that allows the folder pane to be 
+<p>Quick Folder Key Navigation (keynav) is an add-on for Thunderbird that allows the folder pane to be
 quickly navigated by typing part or all of a folder name when it has the focus.</p>
-<p>Note that  single-letter Thunderbird short-cuts (such 
-as "n" and "p" which move to the  next and previous unread messages respectively) do not 
-work in the folder pane when key navigation is enabled.  Therefore, There is an 
-option to turn key navigation on/off, as well as for adding this item to 
+<p>Note that  single-letter Thunderbird short-cuts (such
+as "n" and "p" which move to the  next and previous unread messages respectively) do not
+work in the folder pane when key navigation is enabled.  Therefore, There is an
+option to turn key navigation on/off, as well as for adding this item to
 the context menu when the folder pane has the focus.</p>
 
 <h1>Where to Get keynav</h1>
@@ -39,11 +39,11 @@ the context menu when the folder pane has the focus.</p>
 <p><a href="keynav@andrew.hart.xpi"><b>Download keynav</b></a></p>
 
 <p>The source code for keynav is available on <a href="https://github.com/hartag/keynav.git">gitHub</a>. Alternatively, the git repository can be cloned directly at the command line by typing<br/>
-	<code>
-		git clone https://github.com/hartag/keynav.git keynav
-		</code><br/>
-	which places a copy of the repository in a directory called "keynav".
-	</p>
+  <code>
+    git clone https://github.com/hartag/keynav.git keynav
+    </code><br/>
+  which places a copy of the repository in a directory called "keynav".
+  </p>
 
 <h1 id="install">How to Install keynav</h1>
 
@@ -54,36 +54,36 @@ the context menu when the folder pane has the focus.</p>
   <li>Click on the Tools menu and then click on Add-ons to open the Add-ons Manager. From the keyboard, this can be done by typing Alt+t followed by a.</li>
   <li>Click on the "Tools for all add-ons" button, which appears as a cog wheel. It is just before the "Search all add-ons" edit field in the tab order.
       <ul>
-      	at the location of the button on screen.
+        at the location of the button on screen.
 <div><button onclick="toggleSuggestions()" id="suggestionsButton">Show some suggestions for how to accomplish this.</button></div>
 <div id="suggestions" style="display:none;">
-	<p>First use Tab and Shift+Tab to move the focus to the "Tools for all add-ons" button.</p>
-	<p>If you are using Orca on Linux, you must press Orca Modifier+a to switch Orca into focus Mode before proceeding.</p>
-	<p>Next, you must move the mouse pointer to the button and then click the left mouse button to open the menu. The following table shows the commands for doing this in various screen readers.</p>
-	<table>
-		<tr><th>Operation</th><th>Desktop Command</th><th>Laptop Command</th></tr>
-		<tr><td colspan="3">NVDA</td></tr>
-		<tr>
-			<td>Move mouse to focused object</td><td>NumpadSlash</td><td>NVDA+shift+m</td>
-		</tr>
-		<tr>
-			<td>Click left mouse button</td><td>NVDA+NumpadSlash</td><td>NVDA+[</td>
-		</tr>
-		<tr><td colspan="3">JAWS for Windows</td></tr>
-		<tr>
-			<td>Move mouse to focused object</td><td>JAWSKey+NumpadMinus</td><td>JAWSKey+[</td>
-		</tr>
-		<tr>
-			<td>Click left mouse button</td><td>NumpadSlash</td><td>JAWSKey+8</td>
-		</tr>
+  <p>First use Tab and Shift+Tab to move the focus to the "Tools for all add-ons" button.</p>
+  <p>If you are using Orca on Linux, you must press Orca Modifier+a to switch Orca into focus Mode before proceeding.</p>
+  <p>Next, you must move the mouse pointer to the button and then click the left mouse button to open the menu. The following table shows the commands for doing this in various screen readers.</p>
+  <table>
+    <tr><th>Operation</th><th>Desktop Command</th><th>Laptop Command</th></tr>
+    <tr><td colspan="3">NVDA</td></tr>
+    <tr>
+      <td>Move mouse to focused object</td><td>NumpadSlash</td><td>NVDA+shift+m</td>
+    </tr>
+    <tr>
+      <td>Click left mouse button</td><td>NVDA+NumpadSlash</td><td>NVDA+[</td>
+    </tr>
+    <tr><td colspan="3">JAWS for Windows</td></tr>
+    <tr>
+      <td>Move mouse to focused object</td><td>JAWSKey+NumpadMinus</td><td>JAWSKey+[</td>
+    </tr>
+    <tr>
+      <td>Click left mouse button</td><td>NumpadSlash</td><td>JAWSKey+8</td>
+    </tr>
 <tr><td colspan="3">Orca</td></tr>
-		<tr>
-			<td>Move mouse to focused object</td><td>Orca Modifier+KP Divide</td><td>Orca Modifier+9</td>
-		</tr>
-		<tr>
-			<td>Click left mouse button</td><td>KP Divide</td><td>Orca Modifier+7</td>
-		</tr>
-		</table>
+    <tr>
+      <td>Move mouse to focused object</td><td>Orca Modifier+KP Divide</td><td>Orca Modifier+9</td>
+    </tr>
+    <tr>
+      <td>Click left mouse button</td><td>KP Divide</td><td>Orca Modifier+7</td>
+    </tr>
+    </table>
 </div>
 
 </li></ul>
@@ -95,17 +95,17 @@ the context menu when the folder pane has the focus.</p>
 
 <h1>Building From Source</h1>
 
-<p>To build the add-on from source, first download the source code from <a href="https://github.com/hartag/keynav.git">GitHub</a>. In addition to a shell such as bash, the following standard Linux/Unix  
-utilities are needed for building the extension: make, cat, 
+<p>To build the add-on from source, first download the source code from <a href="https://github.com/hartag/keynav.git">GitHub</a>. In addition to a shell such as bash, the following standard Linux/Unix
+utilities are needed for building the extension: make, cat,
 grep, head, sed, zip.</p>
 
 <p>Building the extension is straightforward. After cloning the repository
 or downloading an archive of the repository and extracting it to a
-directory, simply type "make" at the command prompt to build the .xpi 
+directory, simply type "make" at the command prompt to build the .xpi
 file.</p>
 
-<p>In addition, "make version" will display the source code version and 
-"make clean" will clean up the repository folder structure, deleting the zip 
+<p>In addition, "make version" will display the source code version and
+"make clean" will clean up the repository folder structure, deleting the zip
 file, as well as files with names like *.bak, etc.</p>
 
 <p>Once the xpi file has been built, it can be installed using the instructions given above in <a href="#install">How to Install keynav</a>.</p>

--- a/licence.txt
+++ b/licence.txt
@@ -35,7 +35,7 @@ Mozilla Public License Version 2.0
     means any form of the work other than Source Code Form.
 
 1.7. "Larger Work"
-    means a work that combines Covered Software with other material, in 
+    means a work that combines Covered Software with other material, in
     a separate file or files, that is not Covered Software.
 
 1.8. "License"

--- a/manifest.json
+++ b/manifest.json
@@ -30,7 +30,7 @@
   },
 
   "permissions": [
-    "accountsRead", 
+    "accountsRead",
     "storage"
   ],
 

--- a/popup/popup.js
+++ b/popup/popup.js
@@ -56,7 +56,7 @@ async function applySearchToFolderListEvent(event) {
   }
   await applySearchToFolderList(value, true);
 }
-    
+
 async function applySearchToFolderList(value, gotoFirstMatch) {
   console.log(`Value update '${value}'`);
   lastValue = value;
@@ -92,7 +92,7 @@ function getFolders(subFolders, id) {
   return folders;
 }
 
-// Filter allFolders array into folders and hiddenFolders based on folders 
+// Filter allFolders array into folders and hiddenFolders based on folders
 // whose IDs are contained in hiddenFolderSet.
 function splitFoldersIntoSearchableAndHidden() {
   folders = [];
@@ -132,13 +132,13 @@ function populateHiddenFolders() {
 function commonStringLength(str1, str2) {
   if (caseInsensitiveMatch) {
     str1 = str1.toLocaleLowerCase();
-	str2 = str2.toLocaleLowerCase();
+    str2 = str2.toLocaleLowerCase();
   }
   let idx = 0;
   while (idx<str1.length && idx<str2.length && str1[idx]===str2[idx]) {
     idx++;
   }
-  
+
   return idx;
 }
 
@@ -237,8 +237,8 @@ async function showFolderEvent(event) {
     // Select the appropriate option
     hiddenFoldersElement.selectedIndex = idx
   } else {
-    // Since the hidden-folders element is empty, disable the show buttons 
-    // and move focus to the search box 
+    // Since the hidden-folders element is empty, disable the show buttons
+    // and move focus to the search box
     document.getElementById("show-folder").disabled = true;
     document.getElementById("show-all-folders").disabled = true;
     document.getElementById("search-text").focus();
@@ -273,7 +273,7 @@ async function jumpToFolderInNewTab() {
 }
 
 async function load() {
-  // Build flat folder list. 
+  // Build flat folder list.
   let accounts = await messenger.accounts.list(true);
   allFolders = [];
   for (let account of accounts) {
@@ -371,8 +371,8 @@ async function load() {
   document.getElementById("hide-folder").addEventListener("click", hideFolderEvent);
   document.getElementById("show-folder").addEventListener("click", showFolderEvent);
   document.getElementById("show-all-folders").addEventListener("click", showAllFoldersEvent);
- 
-// Retrieve the list of hidden folders from local storage and split the 
+
+// Retrieve the list of hidden folders from local storage and split the
 // folder list into searchable and hidden
   hiddenFolderSet = new Set(await getSetting("hiddenFolders", []));
   splitFoldersIntoSearchableAndHidden();

--- a/popup/popup.js
+++ b/popup/popup.js
@@ -45,11 +45,9 @@ function filterFolders(folders, value, searchType="start", caseSensitive=false) 
   const normalize = (token) => caseSensitive ? token : token.toLocaleLowerCase();
   return folders.filter((folder) =>
     // All search terms have to match
-    searchTerms.every((searchTerm, i) => {
-      if (i === 0 && searchType === "start") {
-        if (!normalize(folder.matchPath[0]).startsWith(searchTerm)) {
-          return false;
-        }
+    searchTerms.every(searchTerm => {
+      if (searchType === "start") {
+        return folder.matchPath.some((token) => normalize(token).startsWith(searchTerm));
       }
       return folder.matchPath.some((token) => normalize(token).includes(searchTerm));
     })
@@ -69,7 +67,7 @@ async function applySearchToFolderList(value, gotoFirstMatch) {
   console.log(`Value update '${value}'`);
   lastValue = value;
   let matchValue = caseInsensitiveMatch ? value.toLocaleLowerCase() : value;
-  currentSubSearch = filterFolders(folders, matchValue, searchType);
+  currentSubSearch = filterFolders(folders, matchValue, searchType, caseInsensitiveMatch);
   // Display results of filtering
   if (gotoFirstMatch || currentSubSearchIdx>=currentSubSearch.length) currentSubSearchIdx = 0;
   if (currentSubSearch.length == 0) {


### PR DESCRIPTION
This adds the feature to support multiple search terms, to resolve <https://github.com/hartag/keynav/issues/16>.

It's especially useful for local folders. For example, if I have the folder structure:

- `Local Folders`
    - `archive`
        - `fooemail`
            - `2026`
                - `[Gmail]`
                    - `Sent Mail`

Then I can search for `foo sent` to go to this folder.

For `Match from start`, the first search term has to match the first folder's name. So `local foo sent` works in that case.

I also normalized spaces to make it easier for editors. The only files with functionality change is `popup.js`.